### PR TITLE
Guard against accidental deletion of external DB

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,3 +60,13 @@ var cleaner = Package['xolvio:cleaner'];
 // delete all collections except myCollection with optional callback
 cleaner.resetDatabase({excludedCollections: ['myCollection']}, callback);
 ```
+
+### When using a database outside of localhost
+This package resets the database configured for Meteor.
+In order to prevent the accidental deletion of a production database, a special flag was added.
+
+If your `MONGO_URL` includes hosts other than `localhost` and you actually intend for this external database to be reset by this package, please set the `ALLOW_CLEANING_REMOTE_DATABASE_DURING_TEST` environment variable to `1`.
+
+```sh
+export ALLOW_CLEANING_REMOTE_DATABASE_DURING_TEST=1
+```

--- a/cleaner.js
+++ b/cleaner.js
@@ -7,6 +7,21 @@ if (Meteor.isServer) {
       );
     }
 
+    // avoid the unintentional deletions of production databases
+    if (typeof process.env.MONGO_URL === 'string') {
+      var mongodbUri = Npm.require('mongodb-uri');
+      const hosts = mongodbUri.parse(process.env.MONGO_URL).hosts;
+      
+      if (hosts.find(h => h.host !== "localhost") 
+          && process.env.ALLOW_CLEANING_REMOTE_DATABASE_DURING_TEST !== '1') {
+        throw Error("Since $MONGO_URL contains hosts other than `localhost` " +
+                    "you should set the special environment variable " +
+                    "ALLOW_CLEANING_REMOTE_DATABASE_DURING_TEST to 1 " +
+                    "as a safety measure."
+        );
+      }
+    }
+
     options = options || {};
     var excludedCollections = ['system.indexes'];
     if (options.excludedCollections) {

--- a/package.js
+++ b/package.js
@@ -6,6 +6,9 @@ Package.describe({
   documentation: 'README.md',
   debugOnly: true,
 });
+Npm.depends({
+  "mongodb-uri": "0.9.7"
+});
 
 Package.onUse(function(api) {
   api.versionsFrom('1.3');


### PR DESCRIPTION
**This is still untested.**
This is my draft for a feature meant to prevent unintended deletion of a production databases.

I am using the `mongodb-uri` package for completeness (and it is also used by Meteor, so while it remains in the same version I believe that Meteor will normalize the dependency). Searching for `localhost` using a RegEx might also work is a weaker test, but mine might be an overkill.

I should add the `'127.0.0.1'` case as well if we use the current method.

What do you think?
