### PR TITLE
Allow user to set a different database

### DIFF
--- a/cleaner.js
+++ b/cleaner.js
@@ -13,7 +13,7 @@ if (Meteor.isServer) {
       excludedCollections = excludedCollections.concat(options.excludedCollections);
     }
 
-    var db = MongoInternals.defaultRemoteCollectionDriver().mongo.db;
+    var db = options.db || MongoInternals.defaultRemoteCollectionDriver().mongo.db;
     var getCollections = Meteor.wrapAsync(db.collections, db);
     var collections = getCollections();
     var appCollections = _.reject(collections, function (col) {


### PR DESCRIPTION
In my current project we need to connect to a different database, which I also want to have cleaned before every test run.

In this PR I allow the user to set his own database for the function `resetDatabase()`.